### PR TITLE
web(FarmV3ApyButton): make query only when required

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -65,7 +65,7 @@ function FarmV3ApyButton_({ farm, existingPosition, isPositionStaked, tokenId }:
 
   const [priceTimeWindow, setPriceTimeWindow] = useState(0)
 
-  const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount)
+  const { ticks: data } = useAllV3Ticks(roiModal.isOpen ? baseCurrency : undefined, quoteCurrency, feeAmount)
 
   const formState = useV3FormState()
 


### PR DESCRIPTION
Continued from https://github.com/dragon-swap-klaytn/dragon-frontend/pull/2

`useAllV3Ticks` is safe to be called only when the `roiModal` is displayed.

However, unlike `useAllV3Ticks`, `usePoolAvgInfo` must be called whether or not the `roiModal` is displayed. This is because the result of the `usePoolAvgInfo` is being used for APR calculation.

This increases the # of requests from 2 to ~39, but it's still a lot lower than 67 on the `main` branch:

<img width="489" alt="Screenshot 2024-10-29 at 10 52 46 PM" src="https://github.com/user-attachments/assets/7127caa8-f22c-436a-8e19-226f12661f77">
